### PR TITLE
Add a script for Warlock Icarus Dash chaining

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ This allows Warlocks to chain two Icarus Dash back-to-back and move very quickly
 #### Note
 
 - Works only on relatively flat ground more or less.
+- Equip sword while dashing to prevent first-person to third-person switch, and subjectively prevent nausea :smiley:
 - The script needs to activate second dash right as the character touches the ground after the first dash, so you might need to adjust the `secondDashDelay` to achieve that. It usually depends on your mobility and any other extra perks, like the exotic Transversive Steps or a light weight frame weapon. The default value is set to `1050` ms which should be just fine for a Tier 6 - Tier 9 Mobility Warlock. To adjust it the thumb rule is: higher the Tier, more the delay value.
 
 

--- a/readme.md
+++ b/readme.md
@@ -186,6 +186,24 @@ This script allows you to afk in certain activities by periodically providing le
 - <kbd>Alt</kbd>+<kbd>A</kbd>: Start the script
 - <kbd>F3</kbd>: Toggle Macro On/Off
 
+### Warlock Icarus Dash Chaining
+
+[`warlock-icarus-dash-chaining.ahk`](https://github.com/preco21/destiny-macros/raw/master/warlock-icarus-dash-chaining.ahk)
+
+This allows Warlocks to chain two Icarus Dash back-to-back and move very quickly.
+
+#### How to use:
+
+- Equip Warlock's top-tree Dawnblade: Attunement of Sky.
+- Press <kbd>F2</kbd> to toggle the script.
+- While sprinting, press <kbd>Z</kbd> to activate a Icarus Dash chain (Keep holding <kbd>W</kbd>, i.e, moving forward)
+
+**NOTE**
+
+- Works more or less only on relatively flat ground.
+- The script needs to activate second dash right as the character touches the ground after the first dash, so you might need to adjust the `secondDashDelay` to achieve that. It usually depends on your mobility and any other extra perks, like the exotic Transversive Steps or a light weight frame weapon. The default value is set to `1050` ms which should be just fine for a Tier 6 - Tier 9 Mobility Warlock. To adjust it the thumb rule is: higher the Tier, more the delay value.
+
+
 ## FAQ
 
 ### Not working! This is bull$h!t

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,18 @@ You may need to remap your keyboard mapping if this conflicts with it.
   - Click `"Save link as..."`.
 - Double-click the file to run.
 
+## Jump to
+- [AFK](#afk)
+- [Flying That Class](#flying-that-class)
+- [Full Auto Trigger System](#full-auto-trigger-system)
+- [Give Me Some Mod Components](#give-me-some-mod-components)
+- [Mirror Ball](#mirror-ball)
+- [Panic Button](#panic-button)
+- [Smart Shopper](#smart-shopper)
+- [The Mountain Top Spammer](#the-mountain-top-spammer)
+- [Warlock Fit Changer](#warlock-fit-changer-for-cycling-lunafaction-boots--phoenix-protocol)
+- [Warlock Icarus Dash Chaining](#warlock-icarus-dash-chaining)
+
 ## Collection
 
 ### Flying That Class
@@ -198,9 +210,9 @@ This allows Warlocks to chain two Icarus Dash back-to-back and move very quickly
 - Press <kbd>F2</kbd> to toggle the script.
 - While sprinting, press <kbd>Z</kbd> to activate a Icarus Dash chain (Keep holding <kbd>W</kbd>, i.e, moving forward)
 
-**NOTE**
+#### Note
 
-- Works more or less only on relatively flat ground.
+- Works only on relatively flat ground more or less.
 - The script needs to activate second dash right as the character touches the ground after the first dash, so you might need to adjust the `secondDashDelay` to achieve that. It usually depends on your mobility and any other extra perks, like the exotic Transversive Steps or a light weight frame weapon. The default value is set to `1050` ms which should be just fine for a Tier 6 - Tier 9 Mobility Warlock. To adjust it the thumb rule is: higher the Tier, more the delay value.
 
 

--- a/readme.md
+++ b/readme.md
@@ -206,7 +206,7 @@ This allows Warlocks to chain two Icarus Dash back-to-back and move very quickly
 
 #### How to use:
 
-- Equip Warlock's top-tree Dawnblade: Attunement of Sky.
+- Equip Warlock's top-tree Dawnblade: Attunement of Sky with Burst Glide jump.
 - Press <kbd>F2</kbd> to toggle the script.
 - While sprinting, press <kbd>Z</kbd> to activate a Icarus Dash chain (Keep holding <kbd>W</kbd>, i.e, moving forward)
 

--- a/warlock-icarus-dash-chaining.ahk
+++ b/warlock-icarus-dash-chaining.ahk
@@ -1,0 +1,34 @@
+#NoEnv
+#SingleInstance Force
+#KeyHistory 0
+SetBatchLines -1
+ListLines Off
+SendMode Input
+
+; Variables and key binds
+secondDashDelay := 1050 ; Change this according to your build mobility
+JumpBind := "Space" ; Default Jump bind
+IcarusDashBind := "x" ; Default Icarus Dash bind
+
+~*F2::
+  Hotkey, ~*Z, Toggle
+return
+
+~*Z::
+  ; First Icarus Dash
+  Send, {%JumpBind%}
+  Sleep, 100
+  Send, {%JumpBind%}
+  Sleep, 130
+  Send, {%IcarusDashBind%}
+
+  ; Wait to touch ground
+  Sleep, secondDashDelay
+
+  ; Second Icarus Dash
+  Send, {%JumpBind%}
+  Sleep, 100
+  Send, {%JumpBind%}
+  Sleep, 130
+  Send, {%IcarusDashBind%}
+return


### PR DESCRIPTION
This script allows Warlocks to move faster by chaining Icarus Dashes. I have tested it on the Leviathan runway and the default timings are adjusted for Warlocks with average (T6-T9) mobility. More details in the `README`.

If this script is added, the number of scripts will reach 10, so I have also added an alphabetically sorted index at the top of `README` to allow jumping to other sections describing the script. Please also verify that I haven't missed adding any section. Thanks!